### PR TITLE
Set pymongo dependency max version to <4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         'Driver for allowing Django to use MongoDB as the database backend.'),
     install_requires=[
         'sqlparse==0.2.4',
-        'pymongo>=3.2.0',
+        'pymongo>=3.2.0, <4.0',
         'django>=2.0',
         'dataclasses>=0.1',
     ],


### PR DESCRIPTION
This change is to avoid numberous breaking changes included on pymongo 4.0
(https://pymongo.readthedocs.io/en/stable/changelog.html#breaking-changes-in-4-0)